### PR TITLE
Failing to get hermitian PSD example working

### DIFF
--- a/src/SDPT3.jl
+++ b/src/SDPT3.jl
@@ -36,7 +36,7 @@ const ALLOWED_OPTIONS = [
 # `SparseMatrixCSC` is returned in SumOfSquares.jl test `sos_horn`
 _array(x::AbstractMatrix) = x
 _array(x::Vector) = x
-_array(x::Float64) = [x]
+_array(x::Union{Float64, Complex{Float64}}) = [x]
 
 # TODO log in objective, OPTION, initial iterates X0, y0, Z0
 # Solve the primal/dual pair
@@ -44,9 +44,10 @@ _array(x::Float64) = [x]
 # s.t. Ax = b,   c - A'x ∈ K
 #       x ∈ K
 function sdpt3(blk::Matrix,
-               At::Vector{<:Union{Matrix{Float64}, SparseMatrixCSC{Float64}}},
-               C::Vector{<:Union{Matrix{Float64}, Vector{Float64}}},
-               b::Vector{Float64}; kws...)
+               At::Vector{<:Union{Matrix{<:Union{Float64, Complex{Float64}}},
+                                  SparseMatrixCSC{<:Union{Float64, Complex{Float64}}}}},
+               C::Vector{<:Union{Matrix{<:Union{Float64, Complex{Float64}}}, Vector{<:Union{Float64, Complex{Float64}}}}},
+               b::Vector{<:Union{Float64, Complex{Float64}}}; kws...)
                #C::Vector{<:Union{Vector{Float64}, SparseVector{Float64}}}, b::Vector{Float64})
     options = Dict{String, Any}(string(key) => value for (key, value) in kws)
     @assert all(i -> size(At[i], 2) == length(b), 1:length(At))

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -36,8 +36,6 @@ end
 
 @testset "Unit" begin
     MOIT.unittest(BRIDGED, CONFIG, [
-        # Need MOI v0.9.5
-        "solve_result_index",
         # Get `termcode` -1, i.e. "relative gap < infeasibility".
         "solve_blank_obj",
         # Get `termcode` 3, i.e. "norm(X) or norm(Z) diverging".

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1,0 +1,31 @@
+using Test
+using SDPT3
+
+@testset "Project to hermitian PSD" begin
+#    blk = ["q" 4.0
+#           "s" 2.0]
+#    C = Union{Matrix{Float64}, Vector{Float64}}[[1.0, 0.0, 0.0, 0.0], zeros(2, 2)]
+#    A = Matrix{Float64}[
+#         [0.0 1.0 0.0 0.0
+#          0.0 0.0 1.0 0.0
+#          0.0 0.0 0.0 1.0]',
+#         [1.0 0.0 0.0
+#          0.0 1.0 0.0
+#          0.0 0.0 1.0]']
+#    b = [1.0, -1.0, -1.0]
+    blk = ["s" 2.0]
+    c = [0.0 1.0
+         1.0 0.0]
+    A = [1.0 0.0 0.0
+         0.0 0.0 1.0]
+    b = [1.0
+         1.0]
+    obj, X, y, Z, info, runhist = sdpt3(blk, [Matrix(A')], [c], b)
+#obj, X, y, Z, info, runhist = sdpt3(blk, [Matrix(A')], C, b)
+    @show obj
+    @show X
+    @show y
+    @show Z
+    @show info
+    @show runhist
+end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -2,25 +2,25 @@ using Test
 using SDPT3
 
 @testset "Project to hermitian PSD" begin
-#    blk = ["q" 4.0
-#           "s" 2.0]
-#    C = Union{Matrix{Float64}, Vector{Float64}}[[1.0, 0.0, 0.0, 0.0], zeros(2, 2)]
-#    A = Matrix{Float64}[
-#         [0.0 1.0 0.0 0.0
-#          0.0 0.0 1.0 0.0
-#          0.0 0.0 0.0 1.0]',
-#         [1.0 0.0 0.0
-#          0.0 1.0 0.0
-#          0.0 0.0 1.0]']
-#    b = [1.0, -1.0, -1.0]
-    blk = ["s" 2.0]
-    c = [0.0 1.0
-         1.0 0.0]
-    A = [1.0 0.0 0.0
-         0.0 0.0 1.0]
-    b = [1.0
-         1.0]
-    obj, X, y, Z, info, runhist = sdpt3(blk, [Matrix(A')], [c], b)
+    blk = ["q" 4.0
+           "s" 2.0]
+    C = Union{Matrix{Float64}, Vector{Float64}}[[1.0, 0.0, 0.0, 0.0], zeros(2, 2)]
+    A = Matrix{Float64}[
+         [0.0 1.0 0.0 0.0
+          0.0 0.0 1.0 0.0
+          0.0 0.0 0.0 1.0]',
+         [1.0 0.0 0.0
+          0.0 √2 0.0
+          0.0 0.0 1.0]']
+    b = [1.0, -√2 + √2 * im, -1.0]
+#    blk = ["s" 2.0]
+#    c = [0.0 1.0
+#         1.0 0.0]
+#    A = [1.0 0.0 0.0
+#         0.0 0.0 1.0]
+#    b = [1.0
+#         1.0]
+    obj, X, y, Z, info, runhist = sdpt3(blk, A, C, b)
 #obj, X, y, Z, info, runhist = sdpt3(blk, [Matrix(A')], C, b)
     @show obj
     @show X


### PR DESCRIPTION
Help is welcome

EDIT: This might be because this feature was removed, see http://www.optimization-online.org/DB_FILE/2010/06/2654.pdf
>  In earlier versions, 2.3 or earlier, SDPT3 could directly handle complex data in SDP,
> i.e., the case where the constraint matrices are hermitian matrices. However, as
> problems with complex data rarely occur in practice, and in an effort to simplify the
> code, we removed this flexibility from subsequent versions